### PR TITLE
First changes for p2

### DIFF
--- a/app/views/prototype-1/check-eligibility/eligible.html
+++ b/app/views/prototype-1/check-eligibility/eligible.html
@@ -18,8 +18,8 @@
       </h1>
       <p>Thank you for the information you have given us. We can confirm you are eligible to apply for QTS using this service.</p>
         <!-- <a href="#" class="govuk-link">check what documents you’ll need to apply</a> -->
-        <a href="/prototype-1/get-prepared/start-prepare" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
-          Check what documents you’ll need to apply
+        <a href="/prototype-1/task-list-2" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
+          Continue
         </a>
 
     </div>

--- a/app/views/prototype-1/get-prepared/documents.html
+++ b/app/views/prototype-1/get-prepared/documents.html
@@ -14,23 +14,32 @@
 
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Your supporting documents</h1>
 
-      <p>You will need to upload digital versions of the following documents before beginning your application.</p> 
+<p>When you apply, you will need to upload scans or photos of your original documents in .pdf, .jpg and .jpeg formats.</p>
 
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Degree certificate</h2>
-      <p>Supply a copy of the Degree Certificate, as issued by the awarding body</p>
-      <hr class="govuk-!-margin-bottom-4">
+<p class="govuk-!-font-weight-bold">If your documents are not in English you’ll also need to provide a certified translation of each.</p>
+
+
+<p class="govuk-heading-l govuk-!-margin-bottom-4"> You will need </P>
+
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Qualifications</h2>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Degree certificate from the awarding university or institution</li> 
+        <li>Official teacher training certificate from the awarding body. This is not required if your teacher training was completed as part of your degree</li>
+        <li>A transcript or diploma supplement of the qualification that led you to be a recognised teacher. This should be issued by the awarding body and show all the modules you studied and the marks you got for each. If your teacher training was completed as part of your degree, you should supply your degree transcript.</li>
+        </ul>
+        <hr class="govuk-!-margin-bottom-4">
+
 
       <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Identification</h2>
-      <p>Supply one of forms of ID from the list below.</p>
-      <p> </p>
-      <p> The supplied document must provide details of your date of birth and your nationalityDocuments should be currently valid and not expired..</p>
+      <p>Supply one form of ID from the list below.</p>
+      <p> The supplied document must provide details of your date of birth and your nationalityDocuments should be currently valid and not expired.</p>
       
 
       <ul class="govuk-list govuk-list--bullet">
         <li>Passport</li> 
-        <li>Driving Licence (nationality not captured?)</li>
+        <li>Driving Licence</li>
         <li>Identity Card</li>
-        <li>Birth Certificate?</li> Certificate
+        <li>Birth Certificate</li>
         </p>
         </ul>
         <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Change of name</h2>
@@ -43,19 +52,16 @@
           </p>
           </ul>
       <hr class="govuk-!-margin-bottom-4">
-      
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Teacher Qualification Certificate</h2>
-      <p>Supply a copy of the Teacher Qualification Certificate, as issued by the awarding body.</p>
-      <hr class="govuk-!-margin-bottom-4">
 
-      {% if  data['nationality'] != "Jamaica"  %}
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Translations</h2>
-      <p>Supply translations.</p>
-      <p>With the exclusion of ID and Change of Name, all supplied, supporting documents in a language other than English (or not bilingual) must be accompanied by a certified English translation.</p>
-      <p>You must not translate supporting documentation yourself.
-        Translation should be done by an independent certified official body or an accredited translator.</p>
-      <hr class="govuk-!-margin-bottom-4">
-      {% endif %}
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Evidence of professional teaching experience since you qualified</h2>
+        <p>We will need to confirm your teaching experience since you became a qualified teacher. To do this, we will need you to provide references.</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>You should provide the name, role and current email address of senior staff at any schools or other settings who will be able to confirm that you have worked as a teacher for at least one school year since you qualified</li> 
+        <li>They should be expecting us to contact them to confirm the size, subject and age range of the classes you have taught, and the dates you worked there. They must be able to communicate in English</li>
+        <li>If you would like to be exempt from undertaking an induction year in England, you should provide details covering 2 years of teaching.</li>
+        </ul>
+        <hr class="govuk-!-margin-bottom-4">
+
 
 
       {% if data['nationality'] == "Canada"  %}
@@ -64,38 +70,36 @@
         <hr class="govuk-!-margin-bottom-4">
 
       {% elseif data['nationality'] == "India"  %}
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Letter of professional standing</h2>
-      <p>Supply a letter of professional standing from the appropriate competent authority in the country where you are recognised as a fully qualified teacher.</p>
-      <p>This may also be known in some countries/territories as:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li> Statement of Professional Standing</li>
-        <li>Letter of Recognition</li>
-        <li>Letter of Confirmation</li>
-        <li>Letter of Reference</li>
-        <li>Confirmation of Tenure</li>
-      </ul>
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Professional standing as a teacher</h2>
+        <p>You will need to provide proof that you are recognised as a teacher by the competent education or teaching department, ministry or authority in the country or territory where you qualified. This must show that:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li> You have completed a course of initial teacher training (ITT) which is recognised by the competent authority in that country or territory.</li>
+            <li> You have successfully completed any period of professional experience comparable to an induction period.</li>
+            <li> Your authorisation to teach in the country or territory has never been suspended, barred, cancelled, revoked or restricted and that you have no sanctions against you. </li>
+          </ul>
+        <p>Ways to prove professional standing:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Online register: If your competent education department or authority has an online register of teachers, you will need to provide us with any reference numbers that we will need to check your record</li>
+          <li>A written statement: the competent authority or territory that recognises you as a teacher must confirm any of the details above that are not available online in writing. This written confirmation must be dated within three months of you applying for QTS.</li>
+          <p>this written statement may also be known as a letter of professional standing, a letter of confirmation, letter of reference, confirmation of tenure or a teaching licence.</p>
+        </ul>
       <hr class="govuk-!-margin-bottom-4">
 
       {% elseif data['nationality'] == "Nigereia"  %}
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Letter of professional standing</h2>
-        <p>Supply a letter of professional standing from the appropriate competent authority in the country where you are recognised as a fully qualified teacher.</p>
-        <p>This may also be known in some countries/territories as:</p>
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Professional standing as a teacher</h2>
+        <p>You will need to provide proof that you are recognised as a teacher by the competent education or teaching department, ministry or authority in the country or territory where you qualified. This must show that:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li> You have completed a course of initial teacher training (ITT) which is recognised by the competent authority in that country or territory.</li>
+            <li> You have successfully completed any period of professional experience comparable to an induction period.</li>
+            <li> Your authorisation to teach in the country or territory has never been suspended, barred, cancelled, revoked or restricted and that you have no sanctions against you. </li>
+          </ul>
+        <p>Ways to prove professional standing:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>Statement of Professional Standing</li>
-          <li>Letter of Recognition</li>
-          <li>Letter of Confirmation</li>
-          <li>Letter of Reference</li>
-          <li>Confirmation of Tenure</li>
-          <p>The letter can be obtained from the licensing body, teaching or education department/ministry/authority of the country or territory where you completed your teacher training or are recognised as a fully qualified teacher.</p>
-          <p>This letter mustL</p>
-          <li>show that you are authorised to teach in that jurisdiction (country or territory)</li>
-          <li>show that you have completed a course of Initial Teacher Training (ITT) which is recognised by the competent authority in that country/territory.</li>
-          <li>show that you have successfully completed any period of professional experience comparable to an induction period.</li>
-          <li>show that your authorisation to teach in the country or territory has never been suspended, barred, cancelled, revoked or restricted and that you have no sanctions against you. </li>
-          <li>be issued by the competent education or teaching department/ministry/authority.</li>
-          <li>be no more than 3 months old when the TRA receives it</li>  
-        </u>
-        <hr class="govuk-!-margin-bottom-4">
+          <li>Online register: If your competent education department or authority has an online register of teachers, you will need to provide us with any reference numbers that we will need to check your record</li>
+          <li>A written statement: the competent authority or territory that recognises you as a teacher must confirm any of the details above that are not available online in writing. This written confirmation must be dated within three months of you applying for QTS.</li>
+          <p>this written statement may also be known as a letter of professional standing, a letter of confirmation, letter of reference, confirmation of tenure or a teaching licence.</p>
+        </ul>
+      <hr class="govuk-!-margin-bottom-4">
       {% endif %}
 
       {% if data['DegreeEnglish'] == "No" and data['nationality'] != "Jamaica"  %}
@@ -134,7 +138,7 @@
         <hr class="govuk-!-margin-bottom-4">
       {% endif %}
 
-      <h2 class="govuk-heading-l">What to do if you can't provide these documents
+      <h2 class="govuk-heading-l govuk-!-margin-bottom-4">What to do if you can't provide these documents
  </h2>
 
       <p>We will need to see all of these documents to process your application. Email us at email@digital.education.gov.uk for help with paperwork.</p>
@@ -144,7 +148,7 @@
         <input type="hidden" name="answers-checked" value="true">
 
         <button type="submit" class="govuk-button" data-module="govuk-button">
-          Continue to task list
+          Continue
         </button>
 
       </form>

--- a/app/views/prototype-1/get-prepared/question-degree-stem.html
+++ b/app/views/prototype-1/get-prepared/question-degree-stem.html
@@ -30,7 +30,10 @@
             }
           },
           hint: {
-            text: "e.g. a degree in Engineering, Physics, IT, Economics etc"
+            text: "You must demonstrate that you have a level of maths proficiency that is equivalent to at least a GCSE in maths at level 4. 
+            For example, this could be your degree, or a school leaving certificate that shows the subjects you studied.
+
+            GCSEs are completed at the end of compulsory education in England (at age 16)."
           },
           items: [
             {

--- a/app/views/prototype-1/get-prepared/start-prepare.html
+++ b/app/views/prototype-1/get-prepared/start-prepare.html
@@ -31,7 +31,7 @@
       <p>You do not have to pay us a fee for using this checker or for making an application for QTS. There may be some costs to pay for the evidence that you need to provide.</p>
 
       <a href="question-nationality" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
-        Start now
+        Continue
       </a>
     </div>
   </div>

--- a/app/views/prototype-1/task-list-2.html
+++ b/app/views/prototype-1/task-list-2.html
@@ -13,7 +13,7 @@
       </h1>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>
-      <p class="govuk-body govuk-!-margin-bottom-7">You can save and return to this application. You'll need to check your eligibility before completing the other sections. For help, <a href="#">contact us</a></p>
+      <p class="govuk-body govuk-!-margin-bottom-7">You can save and return to this application. For help, <a href="#">contact us</a></p>
 
       <ol class="app-task-list">
         <li>

--- a/app/views/prototype-1/task-list-3.html
+++ b/app/views/prototype-1/task-list-3.html
@@ -13,7 +13,7 @@
       </h1>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>
-      <p class="govuk-body govuk-!-margin-bottom-7">You can save and return to this application. You'll need to check your eligibility before completing the other sections. For help, <a href="#">contact us</a></p>
+      <p class="govuk-body govuk-!-margin-bottom-7">You can save and return to this application. For help, <a href="#">contact us</a></p>
 
       <ol class="app-task-list">
         <li>

--- a/app/views/prototype-1/task-list.html
+++ b/app/views/prototype-1/task-list.html
@@ -13,7 +13,7 @@
       </h1>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>
-      <p class="govuk-body govuk-!-margin-bottom-7">You can save and return to this application. You'll need to check your eligibility before completing the other sections. For help, <a href="#">contact us</a></p>
+      <p class="govuk-body govuk-!-margin-bottom-7">You can save and return to this application. For help, <a href="#">contact us</a></p>
 
       <ol class="app-task-list">
         <li>

--- a/app/views/prototype-2/check-your-eligibility.html
+++ b/app/views/prototype-2/check-your-eligibility.html
@@ -80,9 +80,6 @@
     <p>To apply for QTS to teach primary school age children (aged 5 to 11), your knowledge of science (physics, chemistry, biology or a combination of these subjects) must meet a standard equivalent to a UK grade 4 GCSE.</p>
     <p>A GCSE (General Certificate of Secondary Education) is an academic qualification awarded for exams in England, usually taken at age 16. For help understanding UK qualifications and their international equivalents, contact UK ENIC.</p>
 
-    <a href="documents-you-will-need.html" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
-      Continue
-    </a>
     
   </div>
 

--- a/app/views/prototype-2/documents-you-will-need.html
+++ b/app/views/prototype-2/documents-you-will-need.html
@@ -18,7 +18,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
       Documents you will need
     </h1>
 
@@ -69,6 +69,7 @@
         </ul>
 
       <h2 class="govuk-heading-m">Professional teaching experience since you qualified</h2>
+      <p>We will need to confirm your teaching experience since you became a qualified teacher. To do this, we will need you to provide references.</p>
         <ul class="govuk-list govuk-list--bullet">
           <li> You should provide the name, role and current email address of senior staff at any schools or other settings who will be able to confirm that you have worked as a teacher for at least one school year since you qualified.</li>
           <li> They should be expecting us to contact them to confirm the size, subject and age range of the classes you have taught, and the dates you worked there. They must be able to communicate in English</li>
@@ -81,10 +82,6 @@
 
       <h2 class="govuk-heading-m">Primary teachers only - school level science</h2>
       <p>You must demonstrate that you have a level of science knowledge that is equivalent to at least a GCSE in science at level 4. For example, this could be your degree, or a school leaving certificate that shows the subjects you studied.</p>
-
-      <a href="apply-for-qts" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
-        Continue
-      </a>
 
   </div>
 


### PR DESCRIPTION
Reworking the flows to take a user back to a task page in the first prototype/central page in the second prototype - this involves removing the continue buttons from the bottom of the second prototype (step by step navigation pattern)

Various small pieces of content work too
- Adding in a hint to the maths and science question on the first prototype
- Adding in a section about professional experience on the first prototype

Changing buttons form start now to continue, in line with how other services refer to this sort of button

Also changing a bit of formatting on the documents page